### PR TITLE
Add support for Shinco SDZ/YDZ series dehumidifer

### DIFF
--- a/custom_components/tuya_local/devices/shinco_30d_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/shinco_30d_dehumidifier.yaml
@@ -2,6 +2,8 @@ name: Dehumidifier
 products:
   - id: to4nyl9qxvkqmcmk
     name: Klarstein DryFy Connect
+  - id: fvxjwu2oggajswbx
+    name: Shinco SDZ/YDZ-series Dehumidifier # 除湿机 YDZ系列-自主
 primary_entity:
   entity: humidifier
   class: dehumidifier


### PR DESCRIPTION
### Brand/model
Shinco SDZ1-30D-W, but Tuya refers to it as "YDZ-series" in the product information.
The manual I got is also applicable for SDZ1-50D-W.

```
{
  "result": {
    "active_time": 1729086767,
    "bind_space_id": "*****",
    "category": "cs",
    "create_time": 1729086767,
    "custom_name": "",
    "icon": "smart/icon/ay1519883820333cIlrh/e7c0a9016bc467a1c83a99e863f166ce.png",
    "id": "*****",
    "ip": "*****",
    "is_online": true,
    "lat": "*****",
    "local_key": "*****",
    "lon": "*****",
    "model": "",
    "name": "Dehumidifier",
    "product_id": "fvxjwu2oggajswbx",
    "product_name": "除湿机 YDZ系列-自主",
    "sub": false,
    "time_zone": "+02:00",
    "update_time": 1729086768,
    "uuid": "f362406b588feafd"
  },
  "success": true,
[...]
}
```

### Where to buy

- [Amazon FR](https://www.amazon.fr/dp/B09FPBS661)
- [Shinco global (US)](https://shincoglobal.com/product/shinco-sdz1-30p-energy-star-30-pint-dehumidifier-us/)

Visually the same as this "YDZ" series  (as the product info says) on this [other shinco website](http://en.shinco.net/supply/48.html).

### Product id
`fvxjwu2oggajswbx`

### Data points from Tuya
`{"1":"Power","2":"Mode","3":"Humidity","4":"Set Humidity","5":"Anion","6":"Wind Speed","7":"Child Lock","8":"Swing","11":"Fault","12":"Countdown","13":"Remaining Time","101":"Inside Drying","102":"Water Pump"}`

Those are exactly the same as the "Klarstein DryFry Connect" found in "shinco_30d_dehumidifier.yaml", the Tuya product ID is different though.

Seems to be rather generic for the product line, mine does not have "anion" (ionizer), "water pump" nor "swing" (fan rotation) capabilities, but they do show up in the Tuya smart app anyway.

### Screenshot
![Capture d'écran 2024-10-16 181253](https://github.com/user-attachments/assets/66de938a-dd13-4e97-9ec9-a1267b3e1384)
